### PR TITLE
Add error service and error snackbar

### DIFF
--- a/frontend/src/app/components/error-snackbar/error-snackbar.component.ts
+++ b/frontend/src/app/components/error-snackbar/error-snackbar.component.ts
@@ -1,0 +1,41 @@
+import { Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_SNACK_BAR_DATA,
+  MatSnackBarAction,
+  MatSnackBarActions,
+  MatSnackBarLabel,
+  MatSnackBarRef,
+} from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'app-error-snackbar',
+  standalone: true,
+  imports: [MatButtonModule, MatSnackBarLabel, MatSnackBarActions, MatSnackBarAction],
+  template: `<span matSnackBarLabel class="error"> {{ snackBarData }} </span>
+    <span matSnackBarActions>
+      <button
+        class="error-button"
+        mat-button
+        matSnackBarAction
+        (click)="snackBarRef.dismissWithAction()"
+        color="accent"
+      >
+        Close
+      </button>
+    </span> `,
+  styles: `
+    :host {
+      display: flex;
+    }
+
+    .error-button {
+      background-color: var(--error-text-color);
+      --mat-snack-bar-button-color: var(--error-bg-color);
+    }
+  `,
+})
+export class ErrorSnackbarComponent {
+  snackBarRef = inject(MatSnackBarRef);
+  snackBarData = inject(MAT_SNACK_BAR_DATA);
+}

--- a/frontend/src/app/services/error.service.ts
+++ b/frontend/src/app/services/error.service.ts
@@ -1,0 +1,21 @@
+import { Injectable, inject } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+import { ErrorSnackbarComponent } from '@app/components/error-snackbar/error-snackbar.component';
+
+const showDurationMs = 5 * 1000; // 5 seconds
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ErrorService {
+  private readonly _snackBar = inject(MatSnackBar);
+
+  alert(message: string) {
+    this._snackBar.openFromComponent(ErrorSnackbarComponent, {
+      panelClass: 'error-snackbar',
+      duration: showDurationMs,
+      data: message,
+    });
+  }
+}

--- a/frontend/src/app/services/vault.service.ts
+++ b/frontend/src/app/services/vault.service.ts
@@ -25,6 +25,7 @@ import { KeyPair } from '@interfaces/key-pair';
 
 import { AuthService } from './auth.service';
 import { CryptoService } from './crypto.service';
+import { ErrorService } from './error.service';
 
 interface VaultState {
   keyPair: KeyPair | undefined;
@@ -61,6 +62,7 @@ const setupWasmInstance = setupWasm(
 export class VaultService {
   private readonly pb: TypedPocketBase = inject(PocketBase);
   private readonly cryptoService = inject(CryptoService);
+  private readonly _errorService = inject(ErrorService);
   private readonly authService = inject(AuthService);
 
   private readonly pbUserKeyPairsCollection = 'user_key_pairs';
@@ -95,6 +97,9 @@ export class VaultService {
                   return of({ keyPair });
                 } catch (error) {
                   console.error('Error unpacking key pair record', error);
+                  this._errorService.alert(
+                    'Error unlocking vault. Please check your vault password try again. If this continues to fail try refreshing the page or trying again later.',
+                  );
                   return EMPTY;
                 }
               }),

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -28,6 +28,27 @@ $theme: matx.define-theme(
   )
 );
 
+// Supports weights 100-900
+@import '@fontsource-variable/public-sans';
+
+:root {
+  --error-bg-color: #{mat.get-theme-color($theme, 'error', 90)};
+  --error-text-color: #{mat.get-theme-color($theme, 'error', 30)};
+}
+
+html {
+  @include mat.all-component-themes($theme);
+}
+
+html,
+body {
+  height: 100%;
+}
+body {
+  margin: 0;
+  font-family: 'Public Sans Variable', 'Helvetica Neue', sans-serif;
+}
+
 mat-icon.bi {
   font-size: 1rem !important;
   line-height: 1.125rem !important;
@@ -41,18 +62,7 @@ mat-icon.bi {
   backdrop-filter: blur(0.5rem);
 }
 
-// Supports weights 100-900
-@import '@fontsource-variable/public-sans';
-
-html {
-  @include mat.all-component-themes($theme);
-}
-
-html,
-body {
-  height: 100%;
-}
-body {
-  margin: 0;
-  font-family: 'Public Sans Variable', 'Helvetica Neue', sans-serif;
+.error-snackbar {
+  --mdc-snackbar-container-color: var(--error-bg-color);
+  --mdc-snackbar-supporting-text-color: var(--error-text-color);
 }


### PR DESCRIPTION
This PR adds an error service to display a snack bar error message (in red).

Example screenshot when a user inputs their vault password incorrectly

![image](https://github.com/cognos-io/chat.cognos.io/assets/1744908/79d88625-bc21-4fc6-906c-e132bd99d6f6)
