### PR TITLE
Bug fixes on pagination

### DIFF
--- a/frontend/src/app/components/chat/conversation-detail/conversation-detail.component.ts
+++ b/frontend/src/app/components/chat/conversation-detail/conversation-detail.component.ts
@@ -102,9 +102,11 @@ export class ConversationDetailComponent {
   }
 
   constructor() {
-    // Scroll to bottom when something happens in these observables
-    this.messageService.sendMessage$.pipe(takeUntilDestroyed()).subscribe(() => {
-      this.messageListEl()?.scrollToBottom();
+    // Scroll to bottom when messages changes if the user is already at the bottom (so not if they have scrolled up)
+    this.messageService.messages$.pipe(takeUntilDestroyed()).subscribe(() => {
+      if (this.messagesAtBottom()) {
+        setTimeout(() => this.messageListEl()?.scrollToBottom(), 0);
+      }
     });
   }
 }


### PR DESCRIPTION
- Hide the FAB 'scroll to bottom' button if:
  - already at the bottom
  - There are no messages (i.e. it's a new conversation)
- If the user is at the bottom, sending and/or receiving a new message will automatically scroll