### PR TITLE
Update angular to v18

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^18.0.0",
-        "@angular/cdk": "^17.3.8",
+        "@angular/cdk": "^18.0.0",
         "@angular/common": "^18.0.0",
         "@angular/compiler": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@angular/forms": "^18.0.0",
-        "@angular/material": "^17.3.8",
-        "@angular/material-experimental": "^17.3.8",
+        "@angular/material": "^18.0.0",
+        "@angular/material-experimental": "^18.0.0",
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
@@ -1796,9 +1796,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "17.3.8",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-17.3.8.tgz",
-      "integrity": "sha512-9UQovtq1R3iGppBP6c1xgnokhG3LaUObpm6htMyuQ2v034WinemoeMdHbqs/OvyUbqOUttQI/9vz37TVB0DjXA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-18.0.0.tgz",
+      "integrity": "sha512-V0i1SAiT2PTNyugBW0E4fev8G/4XP5FdyX2YD6oc5sNyt3GFcoDNHcz+oEne8+aYVnQ3Ax9Zutq/SQincDHIbw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1806,8 +1806,8 @@
         "parse5": "^7.1.2"
       },
       "peerDependencies": {
-        "@angular/common": "^17.0.0 || ^18.0.0",
-        "@angular/core": "^17.0.0 || ^18.0.0",
+        "@angular/common": "^18.0.0 || ^19.0.0",
+        "@angular/core": "^18.0.0 || ^19.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -1975,9 +1975,9 @@
       }
     },
     "node_modules/@angular/material": {
-      "version": "17.3.8",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-17.3.8.tgz",
-      "integrity": "sha512-P15p3ixO119DvqtFPCUc+9uKlFgwrwoZtKstcdx/knFlw9c+wS5s9SZzTbB2yqjZoBZ4gC92kqbUQI2o7AUbUQ==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-18.0.0.tgz",
+      "integrity": "sha512-4WfMcr4cX3cF7dKz+cXf9YIvhWOJGTP24rbMF5C6eC5K20IK6zgA//Qn0VSTwZkm54Tu9C7kF+CfNLeLy6i5uQ==",
       "dependencies": {
         "@material/animation": "15.0.0-canary.7f224ddd4.0",
         "@material/auto-init": "15.0.0-canary.7f224ddd4.0",
@@ -2022,6 +2022,7 @@
         "@material/tab-scroller": "15.0.0-canary.7f224ddd4.0",
         "@material/textfield": "15.0.0-canary.7f224ddd4.0",
         "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
         "@material/tooltip": "15.0.0-canary.7f224ddd4.0",
         "@material/top-app-bar": "15.0.0-canary.7f224ddd4.0",
         "@material/touch-target": "15.0.0-canary.7f224ddd4.0",
@@ -2029,19 +2030,19 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/animations": "^17.0.0 || ^18.0.0",
-        "@angular/cdk": "17.3.8",
-        "@angular/common": "^17.0.0 || ^18.0.0",
-        "@angular/core": "^17.0.0 || ^18.0.0",
-        "@angular/forms": "^17.0.0 || ^18.0.0",
-        "@angular/platform-browser": "^17.0.0 || ^18.0.0",
+        "@angular/animations": "^18.0.0 || ^19.0.0",
+        "@angular/cdk": "18.0.0",
+        "@angular/common": "^18.0.0 || ^19.0.0",
+        "@angular/core": "^18.0.0 || ^19.0.0",
+        "@angular/forms": "^18.0.0 || ^19.0.0",
+        "@angular/platform-browser": "^18.0.0 || ^19.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/material-experimental": {
-      "version": "17.3.8",
-      "resolved": "https://registry.npmjs.org/@angular/material-experimental/-/material-experimental-17.3.8.tgz",
-      "integrity": "sha512-9/5s02sU602xCiMzHdCL03QiMRfApUrQXf7iJbYPhOqUIjS0aZqMxRkGmQL+mdUgAGaCosD2lY3RERLaWqQfiA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/material-experimental/-/material-experimental-18.0.0.tgz",
+      "integrity": "sha512-5JFMKHXanX5bDBRNr7iLWG6DwjUzrWs3pf8Qg0pJIfGGFdU1UHtgFkSE/h1rob4opUbPI0pOGW3v/N81MnyDiw==",
       "dependencies": {
         "@material/animation": "15.0.0-canary.7f224ddd4.0",
         "@material/auto-init": "15.0.0-canary.7f224ddd4.0",
@@ -2086,6 +2087,7 @@
         "@material/tab-scroller": "15.0.0-canary.7f224ddd4.0",
         "@material/textfield": "15.0.0-canary.7f224ddd4.0",
         "@material/theme": "15.0.0-canary.7f224ddd4.0",
+        "@material/tokens": "15.0.0-canary.7f224ddd4.0",
         "@material/tooltip": "15.0.0-canary.7f224ddd4.0",
         "@material/top-app-bar": "15.0.0-canary.7f224ddd4.0",
         "@material/touch-target": "15.0.0-canary.7f224ddd4.0",
@@ -2093,13 +2095,13 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/animations": "^17.0.0 || ^18.0.0",
-        "@angular/cdk": "17.3.8",
-        "@angular/common": "^17.0.0 || ^18.0.0",
-        "@angular/core": "^17.0.0 || ^18.0.0",
-        "@angular/forms": "^17.0.0 || ^18.0.0",
-        "@angular/material": "17.3.8",
-        "@angular/platform-browser": "^17.0.0 || ^18.0.0"
+        "@angular/animations": "^18.0.0 || ^19.0.0",
+        "@angular/cdk": "18.0.0",
+        "@angular/common": "^18.0.0 || ^19.0.0",
+        "@angular/core": "^18.0.0 || ^19.0.0",
+        "@angular/forms": "^18.0.0 || ^19.0.0",
+        "@angular/material": "18.0.0",
+        "@angular/platform-browser": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@angular/platform-browser": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,13 +1,13 @@
 {
   "dependencies": {
     "@angular/animations": "^18.0.0",
-    "@angular/cdk": "^17.3.8",
+    "@angular/cdk": "^18.0.0",
     "@angular/common": "^18.0.0",
     "@angular/compiler": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@angular/forms": "^18.0.0",
-    "@angular/material": "^17.3.8",
-    "@angular/material-experimental": "^17.3.8",
+    "@angular/material": "^18.0.0",
+    "@angular/material-experimental": "^18.0.0",
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -12,11 +12,11 @@
 // https://material.angular.io/guide/material-3
 // Create the theme object. A theme consists of configurations for individual
 // theming systems such as "color" or "typography".
-$theme: matx.define-theme(
+$theme: mat.define-theme(
   (
     color: (
       theme-type: 'light',
-      primary: matx.$m3-green-palette,
+      primary: mat.$green-palette,
     ),
     typography: (
       brand-family: 'Public Sans Variable',
@@ -28,11 +28,11 @@ $theme: matx.define-theme(
   )
 );
 
-$dark-theme: matx.define-theme(
+$dark-theme: mat.define-theme(
   (
     color: (
       theme-type: 'dark',
-      primary: matx.$m3-green-palette,
+      primary: mat.$green-palette,
     ),
   )
 );


### PR DESCRIPTION
This PR updates Angular and angular material to v18 however there is a problem with ngx-infinite-scroll which currently does not support angular v18.

I [have opened PR](https://github.com/orizens/ngx-infinite-scroll/pull/436) to address this.