### PR TITLE
Switch to pulling image from docker hub

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -127,6 +127,13 @@ run/live:
 		--build.include_ext "go, tpl, tmpl, html, css, scss, js, ts, sql, jpeg, jpg, gif, png, bmp, svg, webp, ico" \
 		--misc.clean_on_exit "true"
 
+## publish/docker: push the docker image to Docker Hub
+.PHONY: publish/docker
+publish/docker: build/docker
+	@GIT_COMMIT=$$(git rev-parse --short HEAD) && \
+	${DOCKER_BINARY} push ${DOCKER_IMAGE_NAME}:$$GIT_COMMIT && \
+	${DOCKER_BINARY} push ${DOCKER_IMAGE_NAME}:latest
+
 # ==================================================================================== #
 # OPERATIONS
 # ==================================================================================== #

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -4,7 +4,7 @@
 MAIN_PACKAGE_PATH := ./cmd/api
 BINARY_NAME := api
 # Should match the repo name in Docker Hub
-DOCKER_IMAGE_NAME := api.cognos.io
+DOCKER_IMAGE_NAME := docker.io/cognosio/api.cognos.io
 # Can be changed to different versions easily
 GO_BINARY := go
 DOCKER_BINARY := docker
@@ -91,11 +91,11 @@ build:
 	# Include additional build steps, like TypeScript, SCSS or Tailwind compilation here...
 	@${GO_BINARY} build -o=/tmp/bin/${BINARY_NAME} ${MAIN_PACKAGE_PATH}
 
-## build/docker: build the docker image
+## build/docker: build the docker image for linux/amd64,linux/arm64
 .PHONY: build/docker
 build/docker:
 	@GIT_COMMIT=$$(git rev-parse --short HEAD) && \
-	${DOCKER_BINARY} build -t ${DOCKER_IMAGE_NAME}:$$GIT_COMMIT -t ${DOCKER_IMAGE_NAME}:latest .
+	${DOCKER_BINARY} build --platform linux/amd64,linux/arm64 -t ${DOCKER_IMAGE_NAME}:$$GIT_COMMIT -t ${DOCKER_IMAGE_NAME}:latest .
 
 ## run: run the application
 .PHONY: run

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       - web-config:/config
 
   backend:
-    build: ./backend
+    image: docker.io/cognosio/api.cognos.io:latest
     restart: unless-stopped
     user: "1001:0"
     networks:


### PR DESCRIPTION
This PR adds the ability to push and pull the image from [Docker Hub](https://hub.docker.com/repository/docker/cognosio/api.cognos.io/general).

Advantage of this is that we're no longer building the image on the server. Decreases deployment time and doesn't use any resources on the server which means minimal influence on operations.

We should still do a git-pull before running the Docker compose commands on the server just to ensure we have the updated files (e.g. docker-compose.yml) but now the server will only pull the latest image rather than consuming CPU to build it.