### PR TITLE
Add a help/contact button to frontend

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -14,6 +14,7 @@
     "pocketbase",
     "Qwen",
     "tailwindcss",
+    "Threema",
     "tweetnacl",
     "typegen"
   ],

--- a/frontend/src/app/components/contact-help-dialog/contact-help-dialog.component.ts
+++ b/frontend/src/app/components/contact-help-dialog/contact-help-dialog.component.ts
@@ -1,13 +1,55 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { MatDialogContent, MatDialogTitle } from '@angular/material/dialog';
 
+import { ProfilePictureComponent } from '../team/profile-picture/profile-picture.component';
+
 @Component({
   selector: 'app-contact-help-dialog',
   standalone: true,
-  imports: [MatDialogTitle, MatDialogContent],
-  template: `<h2 mat-dialog-title>Need help? Want to contact me?</h2>
+  imports: [MatDialogTitle, MatDialogContent, ProfilePictureComponent],
+  template: `<h2 mat-dialog-title class="text-balance">
+      Need help? Want to contact me?
+    </h2>
     <mat-dialog-content>
-      <p>So you want to contact me?</p>
+      <div class="prose text-balance">
+        <p>
+          If you are having problems, you can contact me -
+          <a
+            href="https://www.linkedin.com/in/egjones/"
+            target="_blank"
+            rel="noreferrer"
+            >Ewan</a
+          >
+          the founder - to get direct, personalized support.
+        </p>
+        <ul>
+          <li>
+            Email me:
+            <a class="underline" href="mailto:ewan@cognos.io">ewan&#64;cognos.io</a>
+          </li>
+          <li>
+            Contact me on Threema:
+            <a
+              class="underline"
+              target="_blank"
+              rel="noreferrer"
+              href="https://threema.id/NM4AVD9N"
+              >NM4AVD9N</a
+            >
+          </li>
+        </ul>
+        <p>
+          Let me know what you're having trouble with and I will be happy to help make
+          it better with you.
+        </p>
+        <p>Thank you for using Cognos.</p>
+      </div>
+      <div class="mt-2 size-24 lg:size-40">
+        <app-profile-picture
+          profileName="Ewan Jones"
+          profilePicturePath="assets/img/profile/profile_ewan--square.jpg"
+        ></app-profile-picture>
+      </div>
     </mat-dialog-content>`,
   styles: ``,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/components/contact-help-dialog/contact-help-dialog.component.ts
+++ b/frontend/src/app/components/contact-help-dialog/contact-help-dialog.component.ts
@@ -1,0 +1,15 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { MatDialogContent, MatDialogTitle } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-contact-help-dialog',
+  standalone: true,
+  imports: [MatDialogTitle, MatDialogContent],
+  template: `<h2 mat-dialog-title>Need help? Want to contact me?</h2>
+    <mat-dialog-content>
+      <p>So you want to contact me?</p>
+    </mat-dialog-content>`,
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ContactHelpDialogComponent {}

--- a/frontend/src/app/pages/auth/login/login.component.ts
+++ b/frontend/src/app/pages/auth/login/login.component.ts
@@ -60,6 +60,16 @@ import { AuthService } from '@services/auth.service';
                 </em>
               </p>
             }
+            <p class="text-balance text-center text-sm text-gray-600">
+              By signing up you are agreeing to our
+              <a
+                class="underline"
+                href="https://cognos.io/privacy-policy-and-terms/"
+                target="_blank"
+                rel="noreferrer"
+                >Privacy Policy and Terms</a
+              >.
+            </p>
           </div>
 
           <hr class="my-8" />

--- a/frontend/src/app/pages/auth/login/login.component.ts
+++ b/frontend/src/app/pages/auth/login/login.component.ts
@@ -60,7 +60,7 @@ import { AuthService } from '@services/auth.service';
                 </em>
               </p>
             }
-            <p class="text-balance text-center text-sm text-gray-600">
+            <p class="prose text-balance text-center text-sm text-gray-600">
               By signing up you are agreeing to our
               <a
                 class="underline"

--- a/frontend/src/app/pages/chat/chat.component.html
+++ b/frontend/src/app/pages/chat/chat.component.html
@@ -81,7 +81,7 @@
         <div class="flex justify-end gap-2">
           <button
             mat-icon-button
-            (click)="router.navigate(['', 'auth', 'logout'])"
+            (click)="onOpenHelpDialog()"
             matTooltip="Get help or contact me"
           >
             <mat-icon fontSet="bi" fontIcon="bi-question-circle"></mat-icon>

--- a/frontend/src/app/pages/chat/chat.component.html
+++ b/frontend/src/app/pages/chat/chat.component.html
@@ -35,7 +35,6 @@
               mat-list-item
               [routerLink]="['c', conversation.record.id]"
               class="conversation-list-item group"
-              #tooltip="matTooltip"
               [matTooltip]="conversation.decryptedData.title"
               matTooltipPosition="after"
             >
@@ -79,10 +78,23 @@
             </mat-menu>
           }
         </mat-nav-list>
-        <button mat-button (click)="router.navigate(['', 'auth', 'logout'])">
-          <mat-icon fontSet="bi" fontIcon="bi-box-arrow-right"></mat-icon>
-          <ng-container i18n="button|action to log user out"> Logout </ng-container>
-        </button>
+        <div class="flex justify-end gap-2">
+          <button
+            mat-icon-button
+            (click)="router.navigate(['', 'auth', 'logout'])"
+            matTooltip="Get help or contact me"
+          >
+            <mat-icon fontSet="bi" fontIcon="bi-question-circle"></mat-icon>
+          </button>
+
+          <button
+            mat-icon-button
+            (click)="router.navigate(['', 'auth', 'logout'])"
+            matTooltip="Logout"
+          >
+            <mat-icon fontSet="bi" fontIcon="bi-box-arrow-right"></mat-icon>
+          </button>
+        </div>
       </div>
     </mat-sidenav>
     <mat-sidenav-content role="main">

--- a/frontend/src/app/pages/chat/chat.component.ts
+++ b/frontend/src/app/pages/chat/chat.component.ts
@@ -16,6 +16,7 @@ import { Subject, takeUntil } from 'rxjs';
 
 import { CognosLogoComponent } from '@app/components/cognos-logo/cognos-logo.component';
 import { ConfirmationDialogComponent } from '@app/components/confirmation-dialog/confirmation-dialog.component';
+import { ContactHelpDialogComponent } from '@app/components/contact-help-dialog/contact-help-dialog.component';
 import { EditConversationDialogComponent } from '@app/components/edit-conversation-dialog/edit-conversation-dialog.component';
 
 import { ConversationService } from '../../services/conversation.service';
@@ -62,6 +63,10 @@ export class ChatComponent implements OnDestroy {
   ngOnDestroy(): void {
     this._destroyed$.next();
     this._destroyed$.complete();
+  }
+
+  onOpenHelpDialog() {
+    this.dialog.open(ContactHelpDialogComponent);
   }
 
   onRenameConversation(conversationId: string) {


### PR DESCRIPTION
This PR changes the button layout and adds a help/support modal that shows Ewan's profile picture, email address and Threema ID.

<img width="802" alt="image" src="https://github.com/cognos-io/chat.cognos.io/assets/1744908/574f0aea-92cf-4468-8fff-3fc03f173833">
