### PR TITLE
Add support for OpenAI GPT 4o

### DIFF
--- a/backend/pkg/proxy/openai.go
+++ b/backend/pkg/proxy/openai.go
@@ -19,6 +19,7 @@ var (
 
 var openAIModelMapping = map[string]string{
 	"gpt-3.5-turbo": openai.GPT3Dot5Turbo,
+	"gpt-4o":        openai.GPT4o,
 }
 
 type OpenAI struct {

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -19,6 +19,7 @@
     "typegen"
   ],
   "cSpell.ignoreWords": [
+    "Omni",
     "auths",
     "blakejs",
     "devkit",

--- a/frontend/src/app/interfaces/model.ts
+++ b/frontend/src/app/interfaces/model.ts
@@ -25,6 +25,19 @@ const openAiGpt35TurboModel: Model = {
   tags: [{ title: 'openai' }, { title: 'general-purpose' }],
 };
 
+const openAiGpt4oModel: Model = {
+  id: 'openai:gpt-4o',
+  name: 'Open AI - GPT 4 Omni',
+  slug: 'open-ai---gpt-4o',
+  description: "OpenAI's GPT 4 Omni (GPT4o) model",
+  inputContextLength: 128_000,
+  tags: [
+    { title: 'openai' },
+    { title: 'general-purpose' },
+    { title: 'high-intelligence' },
+  ],
+};
+
 const cloudflareLlama38bInstruct: Model = {
   id: 'cloudflare:llama-3-8b-instruct',
   name: 'Cloudflare - Llama3 8B Instruct',
@@ -73,6 +86,7 @@ const cloudflareDeepseekMath7bInstruct: Model = {
 export const defaultModel = openAiGpt35TurboModel;
 export const hardCodedModels = [
   openAiGpt35TurboModel,
+  openAiGpt4oModel,
   cloudflareLlama38bInstruct,
   cloudflareQwen157BChat,
   cloudflareMistral7bInstruct,


### PR DESCRIPTION
This PR adds support for OpenAI's GPT-4o, a more advanced model than GPT3.5-turbo but cheaper than GPT-4-turbo

<img width="790" alt="image" src="https://github.com/cognos-io/chat.cognos.io/assets/1744908/36285ccc-5785-4adf-92db-246871d83a42">
