### PR TITLE
Add names to message context

### DIFF
--- a/backend/pkg/compat/openai/openai.go
+++ b/backend/pkg/compat/openai/openai.go
@@ -97,6 +97,9 @@ func EchoHandler(
 		if err := c.Bind(&req); err != nil {
 			return apis.NewBadRequestError("Failed to read request data", err)
 		}
+		// Add the user ID to the request. It's nothing personal but is used to help
+		// identify abuse of our AI providers
+		req.User = owner.ID
 
 		// Validate the incoming request
 		if req.Metadata.Cognos.AgentID == "" {

--- a/frontend/src/app/services/agent.service.ts
+++ b/frontend/src/app/services/agent.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Signal, computed } from '@angular/core';
+import { Injectable, Signal, computed, signal } from '@angular/core';
 
 import { Observable, map } from 'rxjs';
 
@@ -55,7 +55,10 @@ export class AgentService {
 
   public selectAgent = this.state.selectAgent;
 
-  public getAgent(id: string): Signal<Agent | undefined> {
+  public getAgent(id: string | undefined): Signal<Agent | undefined> {
+    if (!id) {
+      return signal(undefined);
+    }
     return computed(() => this.state().agentList.find((agent) => agent.id === id));
   }
 }

--- a/frontend/src/app/services/conversation.service.ts
+++ b/frontend/src/app/services/conversation.service.ts
@@ -174,7 +174,7 @@ export class ConversationService {
         return filteredConversations().sort((a, b) => {
           // TODO(ewan): Include the most recent message
           // Sort the conversations by the most recently updated
-          return b.record.updated.localeCompare(a.record.created);
+          return b.record.updated.localeCompare(a.record.updated);
         });
       });
 

--- a/frontend/src/app/services/conversation.service.ts
+++ b/frontend/src/app/services/conversation.service.ts
@@ -249,6 +249,18 @@ export class ConversationService {
           }),
         );
       },
+      updateConversationUpdatedTimeNow: (state, $: Observable<{ id: string }>) =>
+        $.pipe(
+          map(({ id }) => {
+            const conversations = state().conversations;
+            const index = conversations.findIndex((c) => c.record.id === id);
+            if (index === -1) return state();
+            conversations[index].record.updated = new Date().toISOString();
+            return {
+              conversations: [...conversations],
+            };
+          }),
+        ),
     },
   });
 
@@ -277,6 +289,9 @@ export class ConversationService {
   readonly setConversationTitle = this.state.setConversationTitle;
   readonly isTemporaryConversation = this.state.isTemporaryConversation;
   readonly setIsTemporaryConversation = this.state.setIsTemporaryConversation;
+
+  readonly updateConversationUpdatedTimeNow =
+    this.state.updateConversationUpdatedTimeNow;
 
   /**
    * Creates a conversation in the PocketBase backend.

--- a/frontend/src/app/services/message.service.ts
+++ b/frontend/src/app/services/message.service.ts
@@ -168,6 +168,15 @@ export class MessageService {
 
       // when a message is sent, add it to the list of messages and send it to our upstream API
       this._cleanedMessage$.pipe(
+        tap(() => {
+          const conversation = this._conversationService.conversation();
+          if (!conversation) {
+            return;
+          }
+          this._conversationService.updateConversationUpdatedTimeNow({
+            id: conversation.record.id,
+          });
+        }),
         exhaustMap((messageRequest) => {
           if (!messageRequest.parentMessageId) {
             // Take the most recent message as the parent message

--- a/frontend/src/app/services/message.service.ts
+++ b/frontend/src/app/services/message.service.ts
@@ -548,6 +548,12 @@ export class MessageService {
       context.unshift({
         role: message.decryptedData.owner_id ? 'user' : 'assistant',
         content: message.decryptedData.content,
+        // Adding a name can help the message differentiate participants
+        // Prioritize: userId of who sent it -> agent -> model
+        name:
+          message.decryptedData.owner_id ??
+          this._agentService.getAgent(message.decryptedData.agent_id).name ??
+          this._modelService.getModel(message.decryptedData.model_id).name,
       });
       usedContextLength += messageLength;
 

--- a/frontend/src/app/services/model.service.ts
+++ b/frontend/src/app/services/model.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Signal, computed } from '@angular/core';
+import { Injectable, Signal, computed, signal } from '@angular/core';
 
 import { Observable, map } from 'rxjs';
 
@@ -68,7 +68,10 @@ export class ModelService {
   public selectModel = this.state.selectModel;
   public groupedModels = this.state.groupedModels;
 
-  public getModel(id: string): Signal<Model | undefined> {
+  public getModel(id?: string): Signal<Model | undefined> {
+    if (!id) {
+      return signal(undefined);
+    }
     return computed(() => this.state().modelList.find((model) => model.id === id));
   }
 }


### PR DESCRIPTION
This PR adds names to the messages when sending in the frontend and a userID when sending from the backend.

This helps identify abuse as well as improves the coordination of messages on platforms that support it.

The 'name' is a randomly generated user identifier (e.g `mx4w36ln3g906eb`) and does not leak any personal information.